### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/SimpleOptimizationEnzymeExt.jl
+++ b/ext/SimpleOptimizationEnzymeExt.jl
@@ -3,7 +3,7 @@ module SimpleOptimizationEnzymeExt
 import SimpleOptimization
 import SimpleOptimization.ADTypes: AutoEnzyme
 
-isdefined(Base, :get_extension) ? (using Enzyme) : (using ..Enzyme)
+using Enzyme
 
 #inlining helps GPU compilation
 @inline function SimpleOptimization.instantiate_gradient(f, ::AutoEnzyme)

--- a/ext/SimpleOptimizationForwardDiffExt.jl
+++ b/ext/SimpleOptimizationForwardDiffExt.jl
@@ -3,7 +3,7 @@ module SimpleOptimizationForwardDiffExt
 import SimpleOptimization
 import SimpleOptimization.ADTypes: AutoForwardDiff
 
-isdefined(Base, :get_extension) ? (using ForwardDiff) : (using ..ForwardDiff)
+using ForwardDiff
 
 #inlining helps GPU compilation
 @inline function SimpleOptimization.instantiate_gradient(f, ::AutoForwardDiff)

--- a/src/SimpleOptimization.jl
+++ b/src/SimpleOptimization.jl
@@ -22,10 +22,6 @@ end
 include("./algorithms.jl")
 include("./solve.jl")
 
-if !isdefined(Base, :get_extension)
-    using Requires
-end
-
 export SimpleBFGS, SimpleLBFGS
 
 end


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks