### PR TITLE
Improve static analysis: fix broken imports and type instabilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.0.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 
@@ -19,7 +18,6 @@ SimpleOptimizationForwardDiffExt = "ForwardDiff"
 
 [compat]
 ADTypes = "1"
-DiffEqBase = "6"
 Enzyme = "0.13"
 ForwardDiff = "0.10, 1"
 SciMLBase = "2"
@@ -30,9 +28,10 @@ julia = "1.10"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CUDA", "Enzyme", "ForwardDiff", "Optimization", "StaticArrays"]
+test = ["Test", "CUDA", "Enzyme", "ForwardDiff", "JET", "Optimization", "StaticArrays"]

--- a/src/SimpleOptimization.jl
+++ b/src/SimpleOptimization.jl
@@ -1,7 +1,6 @@
 module SimpleOptimization
 
 import SciMLBase
-import DiffEqBase: AbsSafeBestTerminationMode
 import SciMLBase: _unwrap_val
 using SimpleNonlinearSolve
 using ADTypes
@@ -13,8 +12,11 @@ function instantiate_gradient(f, adtype::ADTypes.AbstractADType)
     strtind = isnothing(_strtind) ? 5 : _strtind + 5
     open_nrmlbrkt_ind = findfirst('(', adtypestr)
     open_squigllybrkt_ind = findfirst('{', adtypestr)
-    open_brkt_ind = isnothing(open_squigllybrkt_ind) ? open_nrmlbrkt_ind :
-                    min(open_nrmlbrkt_ind, open_squigllybrkt_ind)
+    # Handle cases where one or both indices are nothing
+    # Use something to convert Nothing to a fallback value for type stability
+    nrml = something(open_nrmlbrkt_ind, length(adtypestr) + 1)
+    squiggly = something(open_squigllybrkt_ind, length(adtypestr) + 1)
+    open_brkt_ind = min(nrml, squiggly)
     adpkg = adtypestr[strtind:(open_brkt_ind - 1)]
     throw(ArgumentError("The passed automatic differentiation backend choice is not available. Please load the corresponding AD package $adpkg."))
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -32,7 +32,7 @@ function SciMLBase.solve(prob::SciMLBase.OptimizationProblem,
         args...;
         abstol = nothing,
         reltol = nothing,
-        termination_condition = AbsSafeBestTerminationMode(),
+        termination_condition = nothing,
         maxiters = 100,
         kwargs...)
     f = Base.Fix2(prob.f.f, prob.p)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -1,4 +1,4 @@
-using StaticArrays, CUDA, ForwardDiff, Enzyme
+using Optimization, StaticArrays, CUDA, ForwardDiff, Enzyme, SimpleOptimization, Test
 import Base.Iterators: product
 
 CUDA.allowscalar(false)
@@ -7,18 +7,21 @@ function objf(x, p)
     return x[1]^2 + x[2]^2
 end
 
+# Rosenbrock function: minimum at (1, 1) with value 0
+function rosenbrock(x, p)
+    a = isnothing(p) ? 1.0f0 : p[1]
+    b = isnothing(p) ? 100.0f0 : p[2]
+    return (a - x[1])^2 + b * (x[2] - x[1]^2)^2
+end
+
 x0 = @SArray ones(Float32, 2)
+p = @SArray Float32[1.0, 100.0]
 
 optf = OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())
 fd_prob = OptimizationProblem(optf, x0, p)
 
 optf = OptimizationFunction(rosenbrock, Optimization.AutoEnzyme())
 enzyme_prob = OptimizationProblem(optf, x0, p)
-
-x0 = @SArray zeros(Float32, N)
-p = @SArray Float32[1.0, 100.0]
-optf = OptimizationFunction(rosenbrock, Optimization.AutoEnzyme())
-prob = OptimizationProblem(optf, x0, p)
 
 function kernel_function(prob, alg)
     solve(prob, alg)

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,15 @@
+using JET, SimpleOptimization, Test
+
+@testset "JET static analysis" begin
+    # Test that the package passes JET analysis without errors
+    @testset "Package-level analysis" begin
+        result = JET.report_package("SimpleOptimization")
+        reports = JET.get_reports(result)
+        # Filter out any reports about external packages
+        pkg_reports = filter(reports) do report
+            # Only consider reports from SimpleOptimization files
+            occursin("SimpleOptimization", string(report.vst[1].file))
+        end
+        @test length(pkg_reports) == 0
+    end
+end

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -4,12 +4,21 @@ function objf(x, p)
     return x[1]^2 + x[2]^2
 end
 
+# Rosenbrock function: minimum at (1, 1) with value 0
+function rosenbrock(x, p)
+    a = isnothing(p) ? 1.0f0 : p[1]
+    b = isnothing(p) ? 100.0f0 : p[2]
+    return (a - x[1])^2 + b * (x[2] - x[1]^2)^2
+end
+
 using ForwardDiff
 
 x0 = @SArray ones(Float32, 2)
 l1 = objf(x0, nothing)
 
-using ForwardDiff
+# Parameters for rosenbrock: a=1, b=100
+p = @SArray Float32[1.0, 100.0]
+
 optf = OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())
 prob = OptimizationProblem(optf, x0, p)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,3 +7,7 @@ end
 if GROUP == "GPU"
     include("./gpu_tests.jl")
 end
+
+if GROUP == "JET" || GROUP == "All"
+    include("./jet_tests.jl")
+end


### PR DESCRIPTION
## Summary

- Remove broken `DiffEqBase.AbsSafeBestTerminationMode` import that no longer exists in DiffEqBase
- Remove unused `DiffEqBase` dependency from Project.toml
- Use `nothing` default for `termination_condition` (uses solver defaults)
- Fix type instability in `instantiate_gradient` using `something()` for type-stable handling of `findfirst` results
- Add JET.jl tests to the test suite for static analysis verification
- Fix broken test files that used undefined `rosenbrock` and `p` variables

## JET Analysis Results

The package now passes JET.jl static analysis with **zero reports**:

```
[toplevel-info] analyzed 13 top-level definitions
All reports: 0
Test Summary:       | Pass  Total
JET static analysis |    1      1
```

## Test Plan

- [x] JET.jl analysis passes with 0 reports
- [x] ForwardDiff tests pass (SimpleLBFGS and SimpleBFGS both find the minimum)
- [ ] CI tests pass

**Note**: The Enzyme tests have a pre-existing compatibility issue with the current Enzyme version (runtime LLVM error), which is unrelated to these static analysis changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)