### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/ext/SimpleOptimizationEnzymeExt.jl
+++ b/ext/SimpleOptimizationEnzymeExt.jl
@@ -7,6 +7,6 @@ using Enzyme
 
 #inlining helps GPU compilation
 @inline function SimpleOptimization.instantiate_gradient(f, ::AutoEnzyme)
-    (θ, p) -> autodiff_deferred(Reverse, f, Active, Active(θ))[1][1]
+    return (θ, p) -> autodiff_deferred(Reverse, f, Active, Active(θ))[1][1]
 end
 end

--- a/ext/SimpleOptimizationForwardDiffExt.jl
+++ b/ext/SimpleOptimizationForwardDiffExt.jl
@@ -7,7 +7,7 @@ using ForwardDiff
 
 #inlining helps GPU compilation
 @inline function SimpleOptimization.instantiate_gradient(f, ::AutoForwardDiff)
-    (θ, p) -> ForwardDiff.gradient(f, θ)
+    return (θ, p) -> ForwardDiff.gradient(f, θ)
 end
 
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,53 +1,65 @@
-
 # By Pass the highlevel checks for OptimizationProblem for Simple Algorithms
-function SciMLBase.solve(prob::SciMLBase.OptimizationProblem,
+function SciMLBase.solve(
+        prob::SciMLBase.OptimizationProblem,
         opt::SimpleLBFGS,
         args...;
         abstol = nothing,
         reltol = nothing,
         termination_condition = nothing,
         maxiters = 100,
-        kwargs...)
+        kwargs...
+    )
     f = Base.Fix2(prob.f.f, prob.p)
     ∇f = instantiate_gradient(f, prob.f.adtype)
 
     nlprob = NonlinearProblem{false}(∇f, prob.u0)
-    nlsol = solve(nlprob,
+    nlsol = solve(
+        nlprob,
         SimpleLimitedMemoryBroyden(;
             threshold = __get_threshold(opt),
-            linesearch = Val(false));
+            linesearch = Val(false)
+        );
         maxiters,
         abstol,
-        reltol, termination_condition)
+        reltol, termination_condition
+    )
     θ = nlsol.u
 
-    SciMLBase.build_solution(SciMLBase.DefaultOptimizationCache(prob.f, prob.p),
+    return SciMLBase.build_solution(
+        SciMLBase.DefaultOptimizationCache(prob.f, prob.p),
         opt,
         θ,
-        prob.f(θ, prob.p), original = nlsol, retcode = nlsol.retcode)
+        prob.f(θ, prob.p), original = nlsol, retcode = nlsol.retcode
+    )
 end
 
-function SciMLBase.solve(prob::SciMLBase.OptimizationProblem,
+function SciMLBase.solve(
+        prob::SciMLBase.OptimizationProblem,
         opt::SimpleBFGS,
         args...;
         abstol = nothing,
         reltol = nothing,
         termination_condition = nothing,
         maxiters = 100,
-        kwargs...)
+        kwargs...
+    )
     f = Base.Fix2(prob.f.f, prob.p)
     ∇f = instantiate_gradient(f, prob.f.adtype)
 
     nlprob = NonlinearProblem{false}(∇f, prob.u0)
-    nlsol = solve(nlprob,
+    nlsol = solve(
+        nlprob,
         SimpleBroyden(; linesearch = Val(true));
         maxiters,
         abstol,
-        reltol, termination_condition)
+        reltol, termination_condition
+    )
     θ = nlsol.u
 
-    SciMLBase.build_solution(SciMLBase.DefaultOptimizationCache(prob.f, prob.p),
+    return SciMLBase.build_solution(
+        SciMLBase.DefaultOptimizationCache(prob.f, prob.p),
         opt,
         θ,
-        prob.f(θ, prob.p), original = nlsol, retcode = nlsol.retcode)
+        prob.f(θ, prob.p), original = nlsol, retcode = nlsol.retcode
+    )
 end

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -28,8 +28,10 @@ function kernel_function(prob, alg)
     return nothing
 end
 
-@testset "$(nameof(typeof(alg)))" for (alg, prob) in product((SimpleBFGS(), SimpleLBFGS()),
-    (fd_prob, enzyme_prob))
+@testset "$(nameof(typeof(alg)))" for (alg, prob) in product(
+        (SimpleBFGS(), SimpleLBFGS()),
+        (fd_prob, enzyme_prob)
+    )
     @test begin
         try
             @cuda kernel_function(prob, alg)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)